### PR TITLE
Change ami for ssm

### DIFF
--- a/modules/bastion/ec2.tf
+++ b/modules/bastion/ec2.tf
@@ -3,7 +3,7 @@ data "aws_ami" "this" {
   owners      = ["amazon"]
   filter {
     name   = "name"
-    values = ["al2023-ami-2023.8.20250818.0-kernel-6.1-x86_64"]
+    values = ["al2023-ami-*-kernel-6.1-x86_64"] # x86_64
   }
 }
 

--- a/modules/bastion/script/userdata.sh
+++ b/modules/bastion/script/userdata.sh
@@ -58,4 +58,8 @@ curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/inst
 yum install tree -y
 yum install nmap-ncat -y
 yum install ansible -y
+
+# SSMエージェントインストール
+yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+systemctl start amazon-ssm-agent
 --//--


### PR DESCRIPTION
minimal版でないAMIを直接指定することでセッションマネージャーへの接続は可能になりました。

ただ、ワイルドカードを用いるとどうしてもmininal版を除外できない関係で、自動で最新のAMIを取得できるように実装できていません。

ご存じであれば、「minimal版を除く最新AMI」を常に選択できるような実装についておしえていただければと思います。