### PR TITLE
バックアップの設定を任意にする

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,4 +15,5 @@ module "bastion" {
   availability_zone       = var.availability_zone
   disable_api_termination = var.disable_api_termination
   custom_userdata         = var.custom_userdata
+  enable_backup           = var.enable_backup
 }

--- a/modules/bastion/backup.tf
+++ b/modules/bastion/backup.tf
@@ -1,9 +1,10 @@
 resource "aws_backup_plan" "this" {
-  name = var.resource_name
+  count = var.enable_backup ? 1 : 0
+  name  = var.resource_name
 
   rule {
     rule_name         = var.resource_name
-    target_vault_name = aws_backup_vault.this.name
+    target_vault_name = aws_backup_vault.this[0].name
     schedule          = "cron(0 15 ? * MON-FRI *)"
 
     lifecycle {
@@ -13,14 +14,16 @@ resource "aws_backup_plan" "this" {
 }
 
 resource "aws_backup_vault" "this" {
-  name = var.resource_name
+  count = var.enable_backup ? 1 : 0
+  name  = var.resource_name
 }
 
 
 resource "aws_backup_selection" "this" {
+  count        = var.enable_backup ? 1 : 0
   name         = var.resource_name
   iam_role_arn = aws_iam_role.backup.arn
-  plan_id      = aws_backup_plan.this.id
+  plan_id      = aws_backup_plan.this[0].id
 
   resources = [
     aws_instance.this.arn

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -74,3 +74,9 @@ variable "custom_userdata" {
   type        = string
   default     = ""
 }
+
+variable "enable_backup" {
+  description = "バックアップ設定を有効にするかどうか"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,9 @@ variable "custom_userdata" {
   type        = string
   default     = ""
 }
+
+variable "enable_backup" {
+  description = "バックアップ設定を有効にするかどうか"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
`enable_backup`変数の真偽を設定することで、バックアップの作成のオンオフを切り替えられるようにしました。