### PR TITLE
custom_userdataの渡し方の修正

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,6 @@ module "bastion" {
   region                  = var.region
   availability_zone       = var.availability_zone
   disable_api_termination = var.disable_api_termination
-  custom_userdata         = var.custom_userdata
+  custom_userdata         = var.custom_userdata != "" ? file("${path.root}/${var.custom_userdata}") : file("${path.module}/modules/bastion/script/userdata.sh")
   enable_backup           = var.enable_backup
 }

--- a/modules/bastion/ec2.tf
+++ b/modules/bastion/ec2.tf
@@ -19,7 +19,7 @@ resource "aws_instance" "this" {
   iam_instance_profile    = aws_iam_instance_profile.session_manager.name
   vpc_security_group_ids  = [aws_security_group.ec2.id]
   disable_api_termination = var.disable_api_termination
-  user_data               = file(local.userdata_path)
+  user_data               = var.custom_userdata
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
ルートディレクトリにユーザーデータファイルを配置しても読み取られない問題に対し、main.tfの中でファイル内容を読み込むことで解消しました。
自分の環境上で、custom_userdata変数の設定の有無で挙動が分岐することを確認済みです。